### PR TITLE
fixes #53 - nth percentile response time not working as expected

### DIFF
--- a/lightning-core/src/main/java/uk/co/deliverymind/lightning/tests/RespTimeNthPercentileTest.java
+++ b/lightning-core/src/main/java/uk/co/deliverymind/lightning/tests/RespTimeNthPercentileTest.java
@@ -3,6 +3,7 @@ package uk.co.deliverymind.lightning.tests;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.apache.commons.math3.stat.descriptive.rank.Percentile;
 import uk.co.deliverymind.lightning.data.JMeterTransactions;
 import uk.co.deliverymind.lightning.enums.TestResult;
 import uk.co.deliverymind.lightning.utils.IntToOrdConverter;
@@ -32,10 +33,12 @@ public class RespTimeNthPercentileTest extends RespTimeBasedTest {
             transactionCount = transactions.getTransactionCount();
 
             DescriptiveStatistics ds = new DescriptiveStatistics();
+            ds.setPercentileImpl(new Percentile().withEstimationType(Percentile.EstimationType.R_3));
             for (String[] transaction : transactions) {
                 String elapsed = transaction[1];
                 ds.addValue(Double.parseDouble(elapsed));
             }
+
             longestTransactions = transactions.getLongestTransactions();
             actualResult = (int) ds.getPercentile((double) percentile);
             actualResultDescription = String.format(ACTUAL_RESULT_MESSAGE, new IntToOrdConverter().convert(percentile), actualResult);

--- a/lightning-core/src/test/java/uk/co/deliverymind/lightning/tests/RespTimeNthPercentileTestTest.java
+++ b/lightning-core/src/test/java/uk/co/deliverymind/lightning/tests/RespTimeNthPercentileTestTest.java
@@ -88,7 +88,7 @@ public class RespTimeNthPercentileTestTest {
 
     @Test
     public void testExecuteFail() {
-        RespTimeNthPercentileTest test = new RespTimeNthPercentileTest("Test #1", "nthPercRespTimeTest", "Verify 90th percentile", "Search", 90, 245);
+        RespTimeNthPercentileTest test = new RespTimeNthPercentileTest("Test #1", "nthPercRespTimeTest", "Verify 90th percentile", "Search", 90, 220);
         JMeterTransactions jmeterTransactions = new JMeterTransactions();
         jmeterTransactions.add(SEARCH_121_SUCCESS);
         jmeterTransactions.add(SEARCH_125_SUCCESS);
@@ -107,7 +107,7 @@ public class RespTimeNthPercentileTestTest {
 
     @Test
     public void testExecuteAllTransactionsFail() {
-        RespTimeNthPercentileTest test = new RespTimeNthPercentileTest("Test #1", "nthPercRespTimeTest", "Verify 90th percentile", null, 90, 245);
+        RespTimeNthPercentileTest test = new RespTimeNthPercentileTest("Test #1", "nthPercRespTimeTest", "Verify 90th percentile", null, 90, 220);
         JMeterTransactions jmeterTransactions = new JMeterTransactions();
         jmeterTransactions.add(LOGIN_121_SUCCESS);
         jmeterTransactions.add(LOGIN_125_SUCCESS);


### PR DESCRIPTION
Changed quantile function, now using nearest integer.
See https://en.wikipedia.org/wiki/Quantile#Estimating_quantiles_from_a_sample
Also http://commons.apache.org/proper/commons-math/javadocs/api-3.5/org/apache/commons/math3/stat/descriptive/rank/Percentile.EstimationType.html